### PR TITLE
Fixes typo in command description

### DIFF
--- a/src/Commands/Migration/ImportUsers.php
+++ b/src/Commands/Migration/ImportUsers.php
@@ -20,7 +20,7 @@ class ImportUsers extends Command
     /**
      * {@inheritdoc}
      */
-    protected $description = 'Bulk import users from Laravel databse into Slash ID.';
+    protected $description = 'Bulk import users from Laravel database into SlashID.';
 
     /**
      * {@inheritdoc}


### PR DESCRIPTION
Fixes typo in the description of `ImportUsers` command.